### PR TITLE
Make .start() and .end() work on Rust 1.88.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -124,7 +124,7 @@ fn main() {
 
     if proc_macro_span {
         // Enable non-dummy behavior of Span::byte_range and Span::join methods
-        // which require an unstable compiler feature. Enabled when building
+        // which requires an unstable compiler feature. Enabled when building
         // with nightly, unless `-Z allow-feature` in RUSTFLAGS disallows
         // unstable features.
         println!("cargo:rustc-cfg=proc_macro_span");
@@ -132,7 +132,7 @@ fn main() {
 
     if proc_macro_span_location {
         // Enable non-dummy behavior of Span::start and Span::end methods which
-        // require Rust 1.88.
+        // requires Rust 1.88.
         println!("cargo:rustc-cfg=proc_macro_span_location");
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -431,12 +431,12 @@ impl Span {
     #[cfg(span_locations)]
     pub(crate) fn start(&self) -> LineColumn {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(proc_macro_span_location)]
             Span::Compiler(s) => LineColumn {
                 line: s.line(),
                 column: s.column().saturating_sub(1),
             },
-            #[cfg(not(proc_macro_span))]
+            #[cfg(not(proc_macro_span_location))]
             Span::Compiler(_) => LineColumn { line: 0, column: 0 },
             Span::Fallback(s) => s.start(),
         }
@@ -445,7 +445,7 @@ impl Span {
     #[cfg(span_locations)]
     pub(crate) fn end(&self) -> LineColumn {
         match self {
-            #[cfg(proc_macro_span)]
+            #[cfg(proc_macro_span_location)]
             Span::Compiler(s) => {
                 let end = s.end();
                 LineColumn {
@@ -453,7 +453,7 @@ impl Span {
                     column: end.column().saturating_sub(1),
                 }
             }
-            #[cfg(not(proc_macro_span))]
+            #[cfg(not(proc_macro_span_location))]
             Span::Compiler(_) => LineColumn { line: 0, column: 0 },
             Span::Fallback(s) => s.end(),
         }


### PR DESCRIPTION
See https://github.com/dtolnay/proc-macro2/pull/508